### PR TITLE
Fiks bug med datoparsing i Safari

### DIFF
--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -1,7 +1,12 @@
 import { Kurs } from '../models/Kurs';
 
 export const tilDato = (dato: string): Date => {
-    return new Date(dato.replace(' ', 'T'));
+    const [dateAsString, timeAsString] = dato.split(' ');
+    const [year, month, day] = dateAsString.split('-').map(i => parseInt(i));
+    const [hours, minutes] = timeAsString.split(':').map(i => parseInt(i));
+
+    const monthIndex = month - 1;
+    return new Date(year, monthIndex, day, hours, minutes);
 };
 
 export const sammenlignKursPaDato = (a: Kurs, b: Kurs) => {


### PR DESCRIPTION
I Safari parses datoene fra Pindena med UTC, og siden vi ligger på GMT+2 blir tidspunktene forskøvet to timer. I andre browsere antar man lokal tid så parsingen forskyver ikke tidspunktene.

Gjør datoparsing mer spesifikt så det funker i alle browsere.